### PR TITLE
add lifetime column to import mapping

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -543,6 +543,10 @@
                                         <select id="warrantyExpirationColumn" class="column-select"></select>
                                     </div>
                                     <div class="mapping-row">
+                                        <label>Lifetime:</label>
+                                        <select id="lifetimeColumn" class="column-select"></select>
+                                    </div>
+                                    <div class="mapping-row">
                                         <label>2nd Warranty Scope:</label>
                                         <select id="secondaryWarrantyColumn" class="column-select"></select>
                                     </div>

--- a/public/managers/import.js
+++ b/public/managers/import.js
@@ -72,8 +72,9 @@ export class ImportManager {
             const urlColumn = document.getElementById('urlColumn');
             const warrantyColumn = document.getElementById('warrantyColumn');
             const warrantyExpirationColumn = document.getElementById('warrantyExpirationColumn');
+            const lifetimeColumn = document.getElementById('lifetimeColumn');
             const tagsColumn = document.getElementById('tagsColumn');
-            [urlColumn, warrantyColumn, warrantyExpirationColumn, tagsColumn].forEach(select => {
+            [urlColumn, warrantyColumn, warrantyExpirationColumn, lifetimeColumn, tagsColumn].forEach(select => {
                 if (!select) return;
                 select.innerHTML = '<option value="">Select Column</option>';
                 headers.forEach((header, index) => {
@@ -119,6 +120,7 @@ export class ImportManager {
             url: document.getElementById('urlColumn').value,
             warranty: document.getElementById('warrantyColumn').value,
             warrantyExpiration: document.getElementById('warrantyExpirationColumn').value,
+            lifetime: document.getElementById('lifetimeColumn').value,
             secondaryWarranty: document.getElementById('secondaryWarrantyColumn') ? document.getElementById('secondaryWarrantyColumn').value : '',
             secondaryWarrantyExpiration: document.getElementById('secondaryWarrantyExpirationColumn') ? document.getElementById('secondaryWarrantyExpirationColumn').value : '',
             tags: document.getElementById('tagsColumn') ? document.getElementById('tagsColumn').value : ''
@@ -212,6 +214,7 @@ export class ImportManager {
             urlColumn: ["url", "link", "website"],
             warrantyColumn: ["warranty", "warranty scope", "coverage"],
             warrantyExpirationColumn: ["warranty expiration", "warranty expiry", "warranty end", "warranty end date", "expiration", "expiry"],
+            lifetimeColumn: ["lifetime", "lifetime warranty", "is lifetime", "islifetime", "permanent"],
             secondaryWarrantyColumn: ["secondary warranty", "secondary warranty scope", "warranty 2", "warranty2", "warranty scope 2"],
             secondaryWarrantyExpirationColumn: ["secondary warranty expiration", "secondary warranty expiry", "secondary warranty end", "secondary warranty end date", "warranty 2 expiration", "warranty2 expiration", "warranty expiration 2", "warranty expiry 2"],
             tagsColumn: ["tags", "tag", "labels", "categories"]
@@ -261,6 +264,7 @@ export class ImportManager {
             'urlColumn',
             'warrantyColumn',
             'warrantyExpirationColumn',
+            'lifetimeColumn',
             'secondaryWarrantyColumn',
             'secondaryWarrantyExpirationColumn',
             'tagsColumn'
@@ -291,6 +295,7 @@ export class ImportManager {
             'URL',
             'Warranty',
             'Warranty Expiration',
+            'Lifetime',
             'Secondary Warranty',
             'Secondary Warranty Expiration',
             'Tags'
@@ -302,6 +307,7 @@ export class ImportManager {
             if (lower.includes('date') || lower.includes('expiration')) return today;
             if (lower === 'tags') return '"tag1,tag2,tag3"'; // CSV string for tags
             if (lower === 'purchase price') return '123.45';
+            if (lower === 'lifetime') return 'false'; // Boolean value for lifetime warranty
             return `Test ${h}`;
         });
         const csvContent = headers.join(',') + '\n' + testRow.join(',') + '\n';

--- a/server.js
+++ b/server.js
@@ -1123,6 +1123,13 @@ app.post('/api/import-assets', authMiddleware, upload.single('file'), (req, res)
             const get = idx => (mappings[idx] !== undefined && mappings[idx] !== "" && row[mappings[idx]] !== undefined) ? row[mappings[idx]] : "";
             const name = get('name');
             if (!name) continue;
+            // Parse lifetime warranty value
+            const lifetimeValue = get('lifetime');
+            const isLifetime = lifetimeValue ? 
+                (lifetimeValue.toString().toLowerCase() === 'true' || 
+                 lifetimeValue.toString().toLowerCase() === '1' || 
+                 lifetimeValue.toString().toLowerCase() === 'yes') : false;
+
             const asset = {
                 id: generateId(),
                 name: name,
@@ -1135,7 +1142,8 @@ app.post('/api/import-assets', authMiddleware, upload.single('file'), (req, res)
                 link: get('url'),
                 warranty: {
                     scope: get('warranty'),
-                    expirationDate: parseExcelDate(get('warrantyExpiration'))
+                    expirationDate: isLifetime ? null : parseExcelDate(get('warrantyExpiration')),
+                    isLifetime: isLifetime
                 },
                 secondaryWarranty: {
                     scope: get('secondaryWarranty'),


### PR DESCRIPTION
Fixes #4

Summary of Changes
1. Frontend Changes (HTML) Added a new "Lifetime" column mapping row in the import modal (public/index.html) Positioned it logically after "Warranty Expiration" and before "2nd Warranty Scope"
2. Frontend Changes (JavaScript) public/managers/import.js:
Added lifetimeColumn to the column selection dropdowns Added lifetime to the mappings object for form data collection Added auto-mapping rules for common lifetime column names: ["lifetime", "lifetime warranty", "is lifetime", "islifetime", "permanent"] Updated the CSV template to include the "Lifetime" column Added sample data generation for the lifetime column (defaults to false) Added lifetimeColumn to the reset form function

4. Backend Changes (Server) server.js:
Added parsing logic for the lifetime column that accepts multiple formats: true, 1, yes (case-insensitive) → true
Everything else → false
When isLifetime is true, the warranty expiration date is automatically set to null The isLifetime property is properly set in the warranty object

Key Features
Flexible Input: Accepts true/false, 1/0, yes/no (case-insensitive) 
Auto-mapping: Automatically detects common column names for lifetime warranties 
Template Generation: Downloads include the Lifetime column with sample data 
Data Validation: Properly handles the boolean conversion and warranty logic