### PR TITLE
Refactor settings for stability and consistency

### DIFF
--- a/public/managers/charts.js
+++ b/public/managers/charts.js
@@ -1,9 +1,11 @@
 /**
  * Chart Manager class for handling chart creation and updates
  */
+
 export class ChartManager {
-    constructor() {
+    constructor(settingsManager) {
         this.charts = new Map();
+        this.settingsManager = settingsManager;
     }
 
     /**

--- a/public/script.js
+++ b/public/script.js
@@ -28,7 +28,7 @@ import {
 } from '/src/services/render/index.js';
 import { ChartManager } from '/managers/charts.js';
 // Initialize chart manager
-const chartManager = new ChartManager();
+let chartManager = null;
 // Use setupFilePreview from the render index.js
 import { registerServiceWorker } from './helpers/serviceWorkerHelper.js';
 // Import collapsible sections functionality
@@ -1268,7 +1268,8 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Initialize DashboardManager after DOM elements are ready
+    // Initialize ChartManager and DashboardManager after SettingsManager is ready
+    chartManager = new ChartManager(settingsManager);
     dashboardManager = new DashboardManager({
         // DOM elements
         assetDetails,


### PR DESCRIPTION
Fixes: https://github.com/DumbWareio/DumbAssets/issues/18
Refactor settings for stability and consistency

This PR refactors settings management to centralize defaults, streamline client-server configuration flow, and add lifetime warranty support.

- Defines and exposes a single `DEFAULT_SETTINGS` object in `server.js` and updates the config API to include it  
- Overhauls `SettingsManager` to use instance-level storage keys, fetch defaults from `appConfig`, and merge/fallback settings from localStorage or server  
- Updates `DashboardManager` and `ChartManager` to asynchronously consume settings and adjust UI visibility/order logic

| File                                    | Description                                                                 |
| --------------------------------------- | --------------------------------------------------------------------------- |
| server.js                               | Adds `DEFAULT_SETTINGS`, returns it in `/config.js`, simplifies `/api/settings` fallback logic |
| public/script.js                        | Defers `ChartManager` initialization until after `SettingsManager`, passes `settingsManager` |
| public/managers/settings.js             | Introduces `defaultSettings`, instance storage keys, `getSettingsFromLocalStorage()`, and deeper fetch fallback |
| public/managers/dashboardManager.js     | Switches visibility/order/card retrieval to use `SettingsManager` and async defaults |
| public/managers/charts.js               | Updates `ChartManager` constructor to accept `settingsManager`, makes `createWarrantyDashboard` async |
