### PR TITLE
Fix: Add logic to delete asset files and all associated files serverside

### DIFF
--- a/public/managers/import.js
+++ b/public/managers/import.js
@@ -41,6 +41,7 @@ export class ImportManager {
         if (downloadTemplateBtn) {
             downloadTemplateBtn.addEventListener('click', () => this._downloadTemplate());
         }
+        window.resetImportForm = this.resetImportForm.bind(this);
     }
 
     async _handleFileSelection(e) {
@@ -287,7 +288,7 @@ export class ImportManager {
         const mappingContainer = document.querySelector('.column-mapping');
         if (mappingContainer) mappingContainer.style.display = 'none';
     }
-
+    
     _downloadTemplate() {
         // Define the headers for the template CSV
         const headers = [
@@ -311,6 +312,7 @@ export class ImportManager {
         const testRow = headers.map(h => {
             const lower = h.toLowerCase();
             if (lower.includes('date') || lower.includes('expiration')) return today;
+            if (lower === 'url') return 'https://example.com';
             if (lower === 'tags') return '"tag1,tag2,tag3"'; // CSV string for tags
             if (lower === 'purchase price') return '123.45';
             if (lower === 'lifetime') return 'false'; // Boolean value for lifetime warranty

--- a/public/managers/modalManager.js
+++ b/public/managers/modalManager.js
@@ -252,9 +252,6 @@ export class ModalManager {
         // Set up cancel and close buttons
         this.setupSubAssetModalButtons();
         
-        // Show the modal
-        this.subAssetModal.style.display = 'block';
-        this.subAssetModal.querySelector('.modal-content').scrollTop = 0; // Reset scroll position;
         
         // Handle file section expansion
         if (containsExistingFiles) {
@@ -262,6 +259,10 @@ export class ModalManager {
         } else {
             this.collapseSection('#subAssetFileUploader');
         }
+        
+        // Show the modal
+        this.subAssetModal.style.display = 'block';
+        this.subAssetModal.querySelector('.modal-content').scrollTop = 0; // Reset scroll position;
     }
     
     closeSubAssetModal() {

--- a/public/script.js
+++ b/public/script.js
@@ -135,7 +135,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             // Module functions
             openAssetModal: (asset) => modalManager.openAssetModal(asset),
-            openSubAssetModal: (subasset) => modalManager.openSubAssetModal(subasset),
+            openSubAssetModal: (subAsset = null, parentId = null, parentSubId = null) => modalManager.openSubAssetModal(subAsset, parentId, parentSubId),
             deleteAsset,
             deleteSubAsset,
             createSubAssetElement,


### PR DESCRIPTION
Fixes: https://github.com/DumbWareio/DumbAssets/issues/5

Changes:
- Fix save subasset child modal and delete approriate files for those subassets and subassetchildren
- Refactor and simplify delete and update logic for assets and subassets
- update import for url example
- add resetImportForm to window from importmanager instead of script.js
- update subasset file attachment expand/collapse to before showing the modal
- match accepted file types from frontend to backend  for manuals

### Summary
This PR fixes the logic for deleting asset files and associated files on the server while also standardizing file path references with the new DATA_DIR and PUBLIC_DIR constants. Key changes include:
- Refactored and centralized file path references in server.js.
- Reworked asset and subasset file deletion logic using a new asynchronous helper (deleteAssetFileAsync).
- Minor enhancements to the modal and import managers for improved functionality and testing.

| File                         | Description                                       |
| ---------------------------- | ------------------------------------------------- |
| server.js                    | Updated file path constants, refactored deletion logic to use async file removal helper, and adjusted config file path references. |
| public/script.js             | Expanded openSubAssetModal signature to support additional parameters. |
| public/managers/modalManager.js | Reordered modal display code to occur after file section expansion.  |
| public/managers/import.js    | Added a global resetImportForm binding and expanded test row values. |

