### PR TITLE
Add link field for subassets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -360,6 +360,11 @@
                         </div>
                         
                         <div class="form-group">
+                            <label for="subAssetLink">Link</label>
+                            <input type="url" id="subAssetLink" name="link">
+                        </div>
+                        
+                        <div class="form-group">
                             <label for="subAssetWarrantyScope">Warranty Scope</label>
                             <input type="text" id="subAssetWarrantyScope" name="warrantyScope">
                         </div>

--- a/public/managers/modalManager.js
+++ b/public/managers/modalManager.js
@@ -397,6 +397,7 @@ export class ModalManager {
             'subAssetSerial': subAsset.serialNumber || '',
             'subAssetPurchaseDate': subAsset.purchaseDate || '',
             'subAssetPurchasePrice': subAsset.purchasePrice || '',
+            'subAssetLink': subAsset.link || '',
             'subAssetNotes': subAsset.notes || '',
             'subAssetWarrantyScope': subAsset.warranty?.scope || '',
             'subAssetWarrantyExpiration': subAsset.warranty?.expirationDate ? new Date(subAsset.warranty.expirationDate).toISOString().split('T')[0] : ''
@@ -729,6 +730,7 @@ export class ModalManager {
             purchasePrice: parseFloat(document.getElementById('subAssetPurchasePrice')?.value) || null,
             parentId: document.getElementById('parentAssetId')?.value || '',
             parentSubId: document.getElementById('parentSubAssetId')?.value || '',
+            link: document.getElementById('subAssetLink')?.value || '',
             notes: document.getElementById('subAssetNotes')?.value || '',
             tags: subAssetTags,
             warranty: {


### PR DESCRIPTION
Changes Made
Updated HTML Template (public/index.html):
Added a new form group with a link field (subAssetLink) to the sub-asset modal 
Positioned it between the purchase price and warranty scope fields for logical flow 
Updated Modal Manager (public/managers/modalManager.js): populateSubAssetForm method: Added 'subAssetLink': subAsset.link || '' to populate the link field when editing a sub-asset collectSubAssetFormData method: Added link: document.getElementById('subAssetLink')?.value || '' to collect the link value when saving 

Existing Infrastructure Already Supports Links:
The generateAssetInfoHTML function in src/services/render/assetRenderer.js already handles the link display properly It checks for asset.link and renders it as a clickable link with target="_blank" This function is used for both assets and sub-assets, so sub-asset links will be displayed automatically