### PR TITLE
Remove offscreen clicks closing asset/subasset modals

### DIFF
--- a/public/managers/modalManager.js
+++ b/public/managers/modalManager.js
@@ -101,24 +101,7 @@ export class ModalManager {
     }
     
     initializeEventListeners() {
-        // Add escape key listener for all modals
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') {
-                this.closeAssetModal();
-                this.closeSubAssetModal();
-            }
-        });
-        
-        // Add click-off-to-close for modals
-        [this.assetModal, this.subAssetModal].forEach(modal => {
-            if (modal) {
-                modal.addEventListener('mousedown', (e) => {
-                    if (e.target === modal) {
-                        modal.style.display = 'none';
-                    }
-                });
-            }
-        });
+        // Add any event listeners that are needed for the modals
     }
     
     openAssetModal(asset = null) {

--- a/public/script.js
+++ b/public/script.js
@@ -1409,17 +1409,11 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
         // Add click-off-to-close for all modals on overlay click
-        [assetModal, subAssetModal, importModal, settingsModal].forEach(modal => {
+        [importModal, settingsModal].forEach(modal => {
             if (modal) {
                 modal.addEventListener('mousedown', function(e) {
                     if (e.target !== modal) return;
-                    if (modal === assetModal) {
-                        modalManager.closeAssetModal();
-                    }
-                    else if (modal === subAssetModal) {
-                        modalManager.closeSubAssetModal();
-                    }
-                    else if (modal === settingsModal) {
+                    if (modal === settingsModal) {
                         settingsManager.closeSettingsModal();
                     }
                     else {


### PR DESCRIPTION
Fixes: https://github.com/DumbWareio/DumbAssets/issues/51

## Pull Request Overview

This PR addresses the removal of offscreen click behavior for closing asset and subasset modals, which was causing unintended modal closures. Key changes include updating the event listeners in public/script.js to exclude assetModal and subAssetModal and removing related event listeners (escape key and offscreen click) from public/managers/modalManager.js.

| File                            | Description                                                                                           |
| ------------------------------- | ----------------------------------------------------------------------------------------------------- |
| public/script.js                | Removed assetModal and subAssetModal from offscreen click closing; retains explicit handling for settingsModal while leaving importModal in the array with fallback logic. |
| public/managers/modalManager.js | Removed escape key and offscreen click event listeners for asset and subasset modals in favor of a more consolidated event handling approach. |