### PR TITLE
Resolve multi-line CSV field handling in import/export (78, 88)

### DIFF
--- a/public/managers/settings.js
+++ b/public/managers/settings.js
@@ -607,7 +607,7 @@ export class SettingsManager {
         const escapeCsvValue = (value) => {
             if (value === null || value === undefined) return '';
             const str = String(value);
-            if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+            if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
                 return `"${str.replace(/"/g, '""')}"`;
             }
             return str;
@@ -779,7 +779,7 @@ export class SettingsManager {
         const escapeCsvValue = (value) => {
             if (value === null || value === undefined) return '';
             const str = String(value);
-            if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+            if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
                 return `"${str.replace(/"/g, '""')}"`;
             }
             return str;


### PR DESCRIPTION
- Fix CSV export escaping to handle carriage returns (\r) in addition to newlines
- Replace naive string splitting with proper CSV parser for import validation
- Add support for quoted fields containing commas, newlines, and escaped quotes
- Enhance auto-mapping to support Homebox field names (hb.description, hb.notes, hb.warranty_details)
- Update CSV template to include multi-line field examples
- Ensure RFC 4180 compliance for complex CSV field content

Issues resolved:
- #78: Notes don't export with CSV (multi-line fields only showing first line)
- #88: Support multi-line CSV fields (import validation breaking on quoted fields)

Changes:
- public/managers/settings.js: Enhanced escapeCsvValue() function
- public/managers/import.js: Added proper _parseCSV() method and updated validation logic